### PR TITLE
Added a command (and a keybind Ctrl+Shift+Q) that opens a quick selection menu that allows you to easily pick what the active group is

### DIFF
--- a/src/views/bookmark_x/bookmark_tree_view.ts
+++ b/src/views/bookmark_x/bookmark_tree_view.ts
@@ -4,7 +4,7 @@ import {Controller, SpaceMap} from './controller';
 import {BookmarkTreeItem} from './bookmark_tree_item';
 import { Bookmark, Group } from './functional_types';
 import * as util from './util';
-import { ICON_GROUP, ITEM_TYPE_GROUP, ITEM_TYPE_GROUP_LIKE } from './constants';
+import { ICON_GROUP, ITEM_TYPE_GROUP, ITEM_TYPE_GROUP_LIKE, typeIsGroupLike } from './constants';
 import { BmxTreeItem } from './bookmark_tree_data_provider';
 
 class MyViewBadge implements ViewBadge {
@@ -114,11 +114,11 @@ export class BookmarkTreeViewManager {
     static async selectActiveGroup() {
         let wsf = util.getWsfWithActiveEditor();
         let cache = this.controller!.get_root_group(wsf!).cache;
-        let selectedFile: string | undefined = await vscode.window.showQuickPick(
+        let selectedGroupName: string | undefined = await vscode.window.showQuickPick(
             (() => {
                 let options = ["root group"];
                 for (const element of cache.keys().slice(1)) {
-                    if (cache.get(element).type === "group") {
+                    if ((typeIsGroupLike(cache.get(element).type))) {
                         options.push(element)
                     }
                 }
@@ -127,16 +127,16 @@ export class BookmarkTreeViewManager {
             { placeHolder: 'Select Active Group', canPickMany: false }
         );
 
-        if (selectedFile === undefined) { vscode.window.showInformationMessage("active group selection fail: undefined error!"); return; }
+        if (selectedGroupName === undefined) { vscode.window.showInformationMessage("active group selection fail: undefined error!"); return; }
 
-        if (selectedFile === "root group") {
-            selectedFile = "";
+        if (selectedGroupName === "root group") {
+            selectedGroupName = "";
             vscode.window.showInformationMessage(`switch to root group`);
         } else {
-            vscode.window.showInformationMessage(`switch to ` + selectedFile);
+            vscode.window.showInformationMessage(`switch to ` + selectedGroupName);
         }
-        this.controller!.activateGroup(selectedFile, wsf!);
-        this.controller!.get_root_group(wsf!).vicache.refresh_active_icon_status(selectedFile);
+        this.controller!.activateGroup(selectedGroupName, wsf!);
+        this.controller!.get_root_group(wsf!).vicache.refresh_active_icon_status(selectedGroupName);
         return;
     }
 }

--- a/src/views/bookmark_x/bookmark_tree_view.ts
+++ b/src/views/bookmark_x/bookmark_tree_view.ts
@@ -110,4 +110,33 @@ export class BookmarkTreeViewManager {
             vscode.window.showInformationMessage("node is null");
         }
     }
+
+    static async selectActiveGroup() {
+        let wsf = util.getWsfWithActiveEditor();
+        let cache = this.controller!.get_root_group(wsf!).cache;
+        let selectedFile: string | undefined = await vscode.window.showQuickPick(
+            (() => {
+                let options = ["root group"];
+                for (const element of cache.keys().slice(1)) {
+                    if (cache.get(element).type === "group") {
+                        options.push(element)
+                    }
+                }
+                return options;
+            })(),
+            { placeHolder: 'Select Active Group', canPickMany: false }
+        );
+
+        if (selectedFile === undefined) { vscode.window.showInformationMessage("active group selection fail: undefined error!"); return; }
+
+        if (selectedFile === "root group") {
+            selectedFile = "";
+            vscode.window.showInformationMessage(`switch to root group`);
+        } else {
+            vscode.window.showInformationMessage(`switch to ` + selectedFile);
+        }
+        this.controller!.activateGroup(selectedFile, wsf!);
+        this.controller!.get_root_group(wsf!).vicache.refresh_active_icon_status(selectedFile);
+        return;
+    }
 }

--- a/src/views/bookmark_x/contributes.json
+++ b/src/views/bookmark_x/contributes.json
@@ -1,12 +1,5 @@
 {
-  "contributes": {
-		"keybindings": [
-			{
-				"key": "ctrl+shift+q",
-				"command": "bookmark_x.quickSelectActiveGroup",
-				"when": "!inQuickOpen"
-			}
-		],
+	"contributes": {
 		"commands": [
 			{
 				"command": "bookmark_x.toggleBookmark",

--- a/src/views/bookmark_x/contributes.json
+++ b/src/views/bookmark_x/contributes.json
@@ -1,5 +1,12 @@
 {
   "contributes": {
+		"keybindings": [
+			{
+				"key": "ctrl+shift+q",
+				"command": "bookmark_x.quickSelectActiveGroup",
+				"when": "!inQuickOpen"
+			}
+		],
 		"commands": [
 			{
 				"command": "bookmark_x.toggleBookmark",
@@ -67,6 +74,10 @@
 			{
 				"command": "bookmark_x.saveAllWsfState",
 				"title": "Bookmark X: save all workspace state"
+			},
+			{
+				"command": "bookmark_x.quickSelectActiveGroup",
+				"title": "Bookmark X: quick select active group"
 			},
 			{
 				"command": "bookmark_x.downgradeToGroup",

--- a/src/views/bookmark_x/main.ts
+++ b/src/views/bookmark_x/main.ts
@@ -115,7 +115,12 @@ export class bmxLauncher {
       'bookmark_x.saveAllWsfState', () => controller.actionSaveAllWsfState()
     );
     context.subscriptions.push(disposable);
-  
+
+    disposable = vscode.commands.registerCommand(
+      'bookmark_x.quickSelectActiveGroup', () => BookmarkTreeViewManager.selectActiveGroup()
+    );
+    context.subscriptions.push(disposable);
+
     let activeEditor = vscode.window.activeTextEditor;
   
     if (activeEditor) {


### PR DESCRIPTION
# What this PR does / why we need it:
Added a command (and a keybind Ctrl+Shift+Q) that opens a quick selection menu that allows you to easily pick what the active group is. We need this because a lot of users try to be keyboard only and not use mouse much.

<img width="900" alt="Screenshot_1" src="https://github.com/user-attachments/assets/73569f0b-b622-4151-96af-abeb2d0ece2f">

When pressing the keybind it shows you the above menu that has all of the groups of the workspace-folder that is related to the currently active editor.

# Which issue(s) this PR fixes
A lack of a keybind for a critical part of the functionality.

# Special notes for your reviewer:
Let me know if I can help implement this in a different way if you don't like it! I would love to see this feature being part of your extension, it makes everything a bit easier :). Don't feel pressured to accept it if you don't want it, I can just have my fork of it. Hope you have a great day!

