### PR TITLE
feat: Add manual sort support

### DIFF
--- a/src/views/bookmark_x/bookmark_tree_view.ts
+++ b/src/views/bookmark_x/bookmark_tree_view.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ThemeColor, ThemeIcon, ViewBadge } from 'vscode';
+import { ThemeColor, ThemeIcon, ViewBadge,workspace } from 'vscode';
 import {Controller, SpaceMap} from './controller';
 import {BookmarkTreeItem} from './bookmark_tree_item';
 import { Bookmark, Group } from './functional_types';
@@ -70,6 +70,26 @@ export class BookmarkTreeViewManager {
             this.controller!.get_root_group(wsf!).vicache.refresh_active_icon_status(group!.get_full_uri());
         }
     }
+
+    static selectSortItem(treeItem: BookmarkTreeItem){
+        let config = workspace.getConfiguration('bookmarkX');
+        let sortOption = config.get('sort') as string;
+        if(sortOption !== 'manual'){
+            vscode.window.showInformationMessage("Manual sort is disabled. Please enable it in the settings.");
+            return;
+        }
+        const node = treeItem.base;
+        let wsf = this.controller.get_wsf_with_node(node!);
+        this.controller!.enableNodeSorting(node!, wsf!);
+    }
+
+    static deselectSortItem(treeItem: BookmarkTreeItem){
+        const node = treeItem.base;
+        let wsf = this.controller.get_wsf_with_node(node!);
+        this.controller!.disableNodeSorting(node!, wsf!);
+    }
+
+
 
     static deleteGroup(treeItem: BookmarkTreeItem) {
         const group = treeItem.getBaseGroup();

--- a/src/views/bookmark_x/bookmark_tree_view.ts
+++ b/src/views/bookmark_x/bookmark_tree_view.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ThemeColor, ThemeIcon, ViewBadge,workspace } from 'vscode';
+import { ThemeColor, ThemeIcon, ViewBadge, workspace } from 'vscode';
 import {Controller, SpaceMap} from './controller';
 import {BookmarkTreeItem} from './bookmark_tree_item';
 import { Bookmark, Group } from './functional_types';
@@ -72,12 +72,6 @@ export class BookmarkTreeViewManager {
     }
 
     static selectSortItem(treeItem: BookmarkTreeItem){
-        let config = workspace.getConfiguration('bookmarkX');
-        let sortOption = config.get('sort') as string;
-        if(sortOption !== 'manual'){
-            vscode.window.showInformationMessage("Manual sort is disabled. Please enable it in the settings.");
-            return;
-        }
         const node = treeItem.base;
         let wsf = this.controller.get_wsf_with_node(node!);
         this.controller!.enableNodeSorting(node!, wsf!);

--- a/src/views/bookmark_x/constants.ts
+++ b/src/views/bookmark_x/constants.ts
@@ -25,12 +25,8 @@ export const SAVED_WSFSDATA_KEY    = "bookmarkDemo.wsfsData";
 // icons
 // colors are controlled by contributes.
 export const ICON_BOOKMARK = new ThemeIcon("bookmark");
-export const ICON_ACTIVE_GROUP = new ThemeIcon("folder-opened", new ThemeColor("bookmark_x.activeGroupColor"));
+export const ICON_ACTIVE_GROUP = new ThemeIcon("folder-opened", new ThemeColor("statusBarItem.remoteBackground"));
 export const ICON_GROUP = new ThemeIcon("folder");
-// support icon change when sorting later.
-// export const ICON_SORTING_BOOKMARK = new ThemeIcon("bookmark", new ThemeColor("bookmark_x.sortingItemColor"));
-// export const ICON_SORTING_ACTIVE_GROUP = new ThemeIcon("folder-opened", new ThemeColor("bookmark_x.sortingItemColor"));
-// export const ICON_SORTING_GROUP = new ThemeIcon("folder", new ThemeColor("bookmark_x.sortingItemColor"));
 
 export const WSF_TVI_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><title>folder_type_vscode_opened</title><path d="M27.4,5.5H18.2L16.1,9.7H4.3v4H.5L4.3,26.5H29.5V5.5ZM20.2,7.6h7.1V9.7H19.2Zm5.5,6.1H6.6V11.8H27.4v7.626Z" style="fill:#7bb4db"/><path d="M30.257,12.333l-4.324-2.082a1.308,1.308,0,0,0-1.492.253L10.285,23.411a.875.875,0,0,0-.057,1.236.766.766,0,0,0,.057.057l1.157,1.052a.873.873,0,0,0,1.116.049L29.607,12.873A.868.868,0,0,1,31,13.565v-.05A1.311,1.311,0,0,0,30.257,12.333Z" style="fill:#0065a9"/><path d="M30.257,28.788,25.933,30.87a1.308,1.308,0,0,1-1.492-.253L10.285,17.71a.875.875,0,0,1-.057-1.236.766.766,0,0,1,.057-.057l1.157-1.052a.873.873,0,0,1,1.116-.049L29.607,28.248A.868.868,0,0,0,31,27.556v.05A1.311,1.311,0,0,1,30.257,28.788Z" style="fill:#007acc"/><path d="M25.933,30.871a1.308,1.308,0,0,1-1.491-.254.768.768,0,0,0,1.311-.543V11.047a.768.768,0,0,0-1.311-.543,1.306,1.306,0,0,1,1.491-.254l4.324,2.079A1.314,1.314,0,0,1,31,13.512v14.1a1.314,1.314,0,0,1-.743,1.183Z" style="fill:#1f9cf0"/></svg>`
 export const svgBookmark = `<svg id="layer1" data-name="layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32"><defs><style>.cls-1{fill:url(#v);}</style><linearGradient id="v" x1="-3.34" y1="16.24" x2="37.41" y2="15.73" gradientUnits="userSpaceOnUse"><stop offset="0.19" stop-color="#00d39c"/><stop offset="0.75" stop-color="#008c86"/></linearGradient></defs><title>bookmark x logo</title><path class="cls-1" d="M25.8,2.5H9.1A3.55,3.55,0,0,0,5.55,6h0V29.5H22.26V6H15V16.15l-2.66-1.28L9.72,16.15V6H6.84A2.26,2.26,0,0,1,9.1,3.79H25.16V26.6a.65.65,0,1,0,1.29,0V3.15A.65.65,0,0,0,25.8,2.5Z"/></svg>`;

--- a/src/views/bookmark_x/constants.ts
+++ b/src/views/bookmark_x/constants.ts
@@ -17,14 +17,20 @@ export function typeIsBookmarkLike(type: string) {
 export const TREEVIEW_ITEM_CTX_TYPE_BM         = 'bookmark';
 export const TREEVIEW_ITEM_CTX_TYPE_GROUP      = 'group';
 export const TREEVIEW_ITEM_CTX_TYPE_GROUPBM    = 'groupbookmark';
+export const TREEVIEW_ITEM_CTX_TYPE_SORTING_ITEM = 'sortItem';
 
 // state key
 export const SAVED_WSFSDATA_KEY    = "bookmarkDemo.wsfsData";
 
 // icons
+// colors are controlled by contributes.
 export const ICON_BOOKMARK = new ThemeIcon("bookmark");
-export const ICON_ACTIVE_GROUP = new ThemeIcon("folder-opened", new ThemeColor("statusBarItem.remoteBackground"));
+export const ICON_ACTIVE_GROUP = new ThemeIcon("folder-opened", new ThemeColor("bookmark_x.activeGroupColor"));
 export const ICON_GROUP = new ThemeIcon("folder");
+// support icon change when sorting later.
+// export const ICON_SORTING_BOOKMARK = new ThemeIcon("bookmark", new ThemeColor("bookmark_x.sortingItemColor"));
+// export const ICON_SORTING_ACTIVE_GROUP = new ThemeIcon("folder-opened", new ThemeColor("bookmark_x.sortingItemColor"));
+// export const ICON_SORTING_GROUP = new ThemeIcon("folder", new ThemeColor("bookmark_x.sortingItemColor"));
 
 export const WSF_TVI_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><title>folder_type_vscode_opened</title><path d="M27.4,5.5H18.2L16.1,9.7H4.3v4H.5L4.3,26.5H29.5V5.5ZM20.2,7.6h7.1V9.7H19.2Zm5.5,6.1H6.6V11.8H27.4v7.626Z" style="fill:#7bb4db"/><path d="M30.257,12.333l-4.324-2.082a1.308,1.308,0,0,0-1.492.253L10.285,23.411a.875.875,0,0,0-.057,1.236.766.766,0,0,0,.057.057l1.157,1.052a.873.873,0,0,0,1.116.049L29.607,12.873A.868.868,0,0,1,31,13.565v-.05A1.311,1.311,0,0,0,30.257,12.333Z" style="fill:#0065a9"/><path d="M30.257,28.788,25.933,30.87a1.308,1.308,0,0,1-1.492-.253L10.285,17.71a.875.875,0,0,1-.057-1.236.766.766,0,0,1,.057-.057l1.157-1.052a.873.873,0,0,1,1.116-.049L29.607,28.248A.868.868,0,0,0,31,27.556v.05A1.311,1.311,0,0,1,30.257,28.788Z" style="fill:#007acc"/><path d="M25.933,30.871a1.308,1.308,0,0,1-1.491-.254.768.768,0,0,0,1.311-.543V11.047a.768.768,0,0,0-1.311-.543,1.306,1.306,0,0,1,1.491-.254l4.324,2.079A1.314,1.314,0,0,1,31,13.512v14.1a1.314,1.314,0,0,1-.743,1.183Z" style="fill:#1f9cf0"/></svg>`
 export const svgBookmark = `<svg id="layer1" data-name="layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32"><defs><style>.cls-1{fill:url(#v);}</style><linearGradient id="v" x1="-3.34" y1="16.24" x2="37.41" y2="15.73" gradientUnits="userSpaceOnUse"><stop offset="0.19" stop-color="#00d39c"/><stop offset="0.75" stop-color="#008c86"/></linearGradient></defs><title>bookmark x logo</title><path class="cls-1" d="M25.8,2.5H9.1A3.55,3.55,0,0,0,5.55,6h0V29.5H22.26V6H15V16.15l-2.66-1.28L9.72,16.15V6H6.84A2.26,2.26,0,0,1,9.1,3.79H25.16V26.6a.65.65,0,1,0,1.29,0V3.15A.65.65,0,0,0,25.8,2.5Z"/></svg>`;

--- a/src/views/bookmark_x/contributes.jsonc
+++ b/src/views/bookmark_x/contributes.jsonc
@@ -35,22 +35,22 @@
 				"title": "Bookmark X: reveal bookmark in current line"
 			},
 			{
-				"command": "bookmark_x.activateGroup",			// disable in command palette
+				"command": "bookmark_x.activateGroup", // disable in command palette
 				"title": "Activate bookmark group",
 				"icon": "$(eye)"
 			},
 			{
-				"command": "bookmark_x.editGroupName",			// disable in command palette
+				"command": "bookmark_x.editGroupName", // disable in command palette
 				"title": "edit group name",
 				"icon": "$(edit)"
 			},
 			{
-				"command": "bookmark_x.deleteGroup",				// disable in command palette
+				"command": "bookmark_x.deleteGroup", // disable in command palette
 				"title": "Delete bookmark group",
 				"icon": "$(close)"
 			},
 			{
-				"command": "bookmark_x.jumpToBookmark",			// disable in command palette
+				"command": "bookmark_x.jumpToBookmark", // disable in command palette
 				"title": "Jump to book mark"
 			},
 			{
@@ -82,24 +82,24 @@
 				"title": "Bookmark X: downgrade to group"
 			},
 			{
-				"command": "bookmark_x.editBookmarkName",		// disable in command palette(can be improved)
+				"command": "bookmark_x.editBookmarkName", // disable in command palette(can be improved)
 				"title": "edit bookmark name",
 				"icon": "$(edit)"
 			},
 			{
-				"command": "bookmark_x.deleteBookmark",			// disable in command palette(can be improved)
+				"command": "bookmark_x.deleteBookmark", // disable in command palette(can be improved)
 				"title": "Delete bookmark",
 				"icon": "$(close)"
 			},
 			{
-				"command":"bookmark_x:selectSortItem",
-				"title":"Select to sort this item",
-				"icon":"$(filter)"
+				"command": "bookmark_x:selectSortItem",
+				"title": "Bookmark X: Select to sort this item",
+				"icon": "$(filter)"
 			},
 			{
-				"command":"bookmark_x:deselectSortItem",
-				"title":"Deselect the sorting item",
-				"icon":"$(filter-filled)"
+				"command": "bookmark_x:deselectSortItem",
+				"title": "Bookmark X: Deselect the sorting item",
+				"icon": "$(filter-filled)"
 			},
 			{
 				"command": "bookmark_x.moveItemUp",
@@ -143,39 +143,39 @@
 		"menus": {
 			"view/item/context": [
 				{
-					"command":"bookmark_x:selectSortItem",
-					"when":"view == bookmarksByGroup && viewItem != sortItem",
-					"group":"inline"
+					"command": "bookmark_x:selectSortItem",
+					"when": "view == bookmarksByGroup && viewItem && viewItem != sortItem && config.bookmarkX.sort == manual", // root group doesn't have contextValue. 'viewItem' will hide the button for root group.
+					"group": "inline@4" // keep select/deselect to be the last button.
 				},
 				{
-					"command":"bookmark_x:deselectSortItem",
-					"when":"view == bookmarksByGroup && viewItem == sortItem",
-					"group":"inline"
+					"command": "bookmark_x:deselectSortItem",
+					"when": "view == bookmarksByGroup && viewItem && viewItem == sortItem && config.bookmarkX.sort == manual",
+					"group": "inline@4"
 				},
 				{
 					"command": "bookmark_x.activateGroup",
 					"when": "view == bookmarksByGroup && (viewItem == group || viewItem == groupbookmark)",
-					"group": "inline"
+					"group": "inline@1"
 				},
 				{
 					"command": "bookmark_x.editGroupName",
 					"when": "view == bookmarksByGroup && (viewItem == group || viewItem == groupbookmark)",
-					"group": "inline"
+					"group": "inline@3"
 				},
 				{
 					"command": "bookmark_x.deleteGroup",
 					"when": "view == bookmarksByGroup && (viewItem == group || viewItem == groupbookmark)",
-					"group": "inline"
+					"group": "inline@2"
 				},
 				{
 					"command": "bookmark_x.editBookmarkName",
 					"when": "viewItem == bookmark",
-					"group": "inline"
+					"group": "inline@3"
 				},
 				{
 					"command": "bookmark_x.deleteBookmark",
 					"when": "viewItem == bookmark",
-					"group": "inline"
+					"group": "inline@2"
 				},
 				{
 					"command": "bookmark_x.addSubGroup",
@@ -198,12 +198,12 @@
 				},
 				{
 					"command": "bookmark_x.moveItemUp",
-					"when": "view == bookmarksByGroup",
+					"when": "view == bookmarksByGroup && config.bookmarkX.sort == manual",
 					"group": "navigation@2"
 				},
 				{
 					"command": "bookmark_x.moveItemDown",
-					"when": "view == bookmarksByGroup",
+					"when": "view == bookmarksByGroup && config.bookmarkX.sort == manual",
 					"group": "navigation@3"
 				}
 			],
@@ -231,6 +231,22 @@
 				{
 					"command": "bookmark_x.activateGroup",
 					"when": "false"
+				},
+				{
+					"command": "bookmark_x:selectSortItem",
+					"when": "false"
+				},
+				{
+					"command": "bookmark_x:deselectSortItem",
+					"when": "false"
+				},
+				{
+					"command": "bookmark_x.moveItemUp",
+					"when": "false"
+				},
+				{
+					"command": "bookmark_x.moveItemDown",
+					"when": "false"
 				}
 			]
 		},
@@ -245,31 +261,13 @@
 				"bookmarkX.sort": {
 					"type": "string",
 					"default": "group first",
-					"enum": ["group first", "plain", "manual"]
+					"enum": [
+						"group first",
+						"plain",
+						"manual"
+					]
 				}
 			}
-		},
-		"colors":[
-			{
-				"id": "bookmark_x.sortingItemColor",
-				"description": "Color of sorting item icon",
-				"defaults": {
-					"dark":"#007acc",
-					"light":"#007acc",
-					"highContrast": "#007acc",
-					"highContrastLight": "#007acc"
-				}
-			},
-			{
-				"id": "bookmark_x.activeGroupColor",
-				"description": "Color of active bookmark group icon",
-				"defaults": {
-					"dark": "#b67534",
-					"light": "#b67534",
-					"highContrast": "#b67534",
-					"highContrastLight": "#b67534"
-				}
-			}
-		]
+		}
 	}
 }

--- a/src/views/bookmark_x/contributes.jsonc
+++ b/src/views/bookmark_x/contributes.jsonc
@@ -15,7 +15,8 @@
 			},
 			{
 				"command": "bookmark_x.addGroup",
-				"title": "Bookmark X: add group"
+				"title": "Bookmark X: add group",
+				"icon": "$(file-directory-create)"
 			},
 			{
 				"command": "bookmark_x.clearData",
@@ -91,6 +92,26 @@
 				"icon": "$(close)"
 			},
 			{
+				"command":"bookmark_x:selectSortItem",
+				"title":"Select to sort this item",
+				"icon":"$(filter)"
+			},
+			{
+				"command":"bookmark_x:deselectSortItem",
+				"title":"Deselect the sorting item",
+				"icon":"$(filter-filled)"
+			},
+			{
+				"command": "bookmark_x.moveItemUp",
+				"title": "Bookmark X: Move item up",
+				"icon": "$(arrow-up)"
+			},
+			{
+				"command": "bookmark_x.moveItemDown",
+				"title": "Bookmark X: Move item down",
+				"icon": "$(arrow-down)"
+			},
+			{
 				"command": "bmx.showChangelog",
 				"title": "bmx: show changelog"
 			}
@@ -121,6 +142,16 @@
 		],
 		"menus": {
 			"view/item/context": [
+				{
+					"command":"bookmark_x:selectSortItem",
+					"when":"view == bookmarksByGroup && viewItem != sortItem",
+					"group":"inline"
+				},
+				{
+					"command":"bookmark_x:deselectSortItem",
+					"when":"view == bookmarksByGroup && viewItem == sortItem",
+					"group":"inline"
+				},
 				{
 					"command": "bookmark_x.activateGroup",
 					"when": "view == bookmarksByGroup && (viewItem == group || viewItem == groupbookmark)",
@@ -162,7 +193,18 @@
 			"view/title": [
 				{
 					"command": "bookmark_x.addGroup",
-					"when": "view == bookmarksByGroup"
+					"when": "view == bookmarksByGroup",
+					"group": "navigation@1"
+				},
+				{
+					"command": "bookmark_x.moveItemUp",
+					"when": "view == bookmarksByGroup",
+					"group": "navigation@2"
+				},
+				{
+					"command": "bookmark_x.moveItemDown",
+					"when": "view == bookmarksByGroup",
+					"group": "navigation@3"
 				}
 			],
 			"commandPalette": [
@@ -203,9 +245,31 @@
 				"bookmarkX.sort": {
 					"type": "string",
 					"default": "group first",
-					"enum": ["group first", "plain"]
+					"enum": ["group first", "plain", "manual"]
 				}
 			}
-		}
+		},
+		"colors":[
+			{
+				"id": "bookmark_x.sortingItemColor",
+				"description": "Color of sorting item icon",
+				"defaults": {
+					"dark":"#007acc",
+					"light":"#007acc",
+					"highContrast": "#007acc",
+					"highContrastLight": "#007acc"
+				}
+			},
+			{
+				"id": "bookmark_x.activeGroupColor",
+				"description": "Color of active bookmark group icon",
+				"defaults": {
+					"dark": "#b67534",
+					"light": "#b67534",
+					"highContrast": "#b67534",
+					"highContrastLight": "#b67534"
+				}
+			}
+		]
 	}
 }

--- a/src/views/bookmark_x/controller.ts
+++ b/src/views/bookmark_x/controller.ts
@@ -138,7 +138,6 @@ export class Controller {
 
     // move treeitem up or down
     public moveItem(direction: string) {
-        // FIXME support move group and group bookmark.
         let config = workspace.getConfiguration('bookmarkX');
         let sortOption = config.get('sort') as string;
         if (sortOption === 'manual') {

--- a/src/views/bookmark_x/functional_types.ts
+++ b/src/views/bookmark_x/functional_types.ts
@@ -144,6 +144,8 @@ export class Group extends BaseFunctional {
             this.children.sort(Group.sortGroupFirst);  // group在前 bookmark在后
         } else if (sortOption === 'plain') {
             this.children.sort(Group.sortPlain);
+        } else if(sortOption === 'manual') {
+            return;
         } else {
             window.showInformationMessage("sort fail, sort option invalid: "+sortOption);
         }

--- a/src/views/bookmark_x/main.ts
+++ b/src/views/bookmark_x/main.ts
@@ -43,7 +43,26 @@ export class bmxLauncher {
       'bookmark_x.activateGroup', (item: BookmarkTreeItem) => BookmarkTreeViewManager.activateGroup(item)
     );
     context.subscriptions.push(disposable);
+
+    disposable = vscode.commands.registerCommand(
+      'bookmark_x:selectSortItem', (item: BookmarkTreeItem) => BookmarkTreeViewManager.selectSortItem(item)
+    );
+    context.subscriptions.push(disposable);
   
+    disposable = vscode.commands.registerCommand(
+      'bookmark_x:deselectSortItem', (item: BookmarkTreeItem) => BookmarkTreeViewManager.deselectSortItem(item)
+    );
+    context.subscriptions.push(disposable);
+
+    disposable = vscode.commands.registerCommand(
+      'bookmark_x.moveItemUp', () => controller.moveItem('up')
+    );
+    context.subscriptions.push(disposable);
+
+    disposable = vscode.commands.registerCommand(
+      'bookmark_x.moveItemDown', () => controller.moveItem('down')
+    );
+
     // 通过面板-删除分组
     disposable = vscode.commands.registerCommand(
       'bookmark_x.deleteGroup', (item: BookmarkTreeItem) => BookmarkTreeViewManager.deleteGroup(item)

--- a/src/views/refer_link/main.ts
+++ b/src/views/refer_link/main.ts
@@ -124,7 +124,7 @@ export class ReferLinkLauncher {
             jsonData = JSON.parse(_data);
             const [firstSelection] = editor.selections;
             const firstText = editor.document.getText(firstSelection);
-            let newSnip = {
+            let newSnip: { prefix: string, body: string[], description: string } = { // prevent type error
               prefix: '',
               body: [],
               description: '',


### PR DESCRIPTION
A new treeitem inline icon te select/deselect sort item. 
Two arrow icon at view/title/navigation to move the selected sort item. 
Add group command is also moved to the same place to make it more convenient.

icon to select:
![image](https://github.com/user-attachments/assets/b4953adf-922e-40cd-b660-c2466ce1c23e)

icon to deselect:
![image](https://github.com/user-attachments/assets/5257ebe1-073e-46e9-9996-19cc031a19e4)


A 'manual' option is added to settings to enable/disable manual sort.
![image](https://github.com/user-attachments/assets/7d5d8424-7d85-45c9-85f0-0b718b4e0671)

The sort action support all type of treeitem(bookmark/group/groupbookmark).