### PR TITLE
feat: Support icon change when sorting

### DIFF
--- a/src/views/bookmark_x/bookmark_tree_view.ts
+++ b/src/views/bookmark_x/bookmark_tree_view.ts
@@ -61,7 +61,13 @@ export class BookmarkTreeViewManager {
             this.controller!.get_root_group(wsf!).vicache.keys().forEach(key => {
                 // reset icon status
                 let tvi = this.controller!.get_root_group(wsf!).vicache.get(key);
-                if (ITEM_TYPE_GROUP_LIKE.includes(tvi.base!.type)) { tvi.iconPath = ICON_GROUP; }
+                if (ITEM_TYPE_GROUP_LIKE.includes(tvi.base!.type)) { 
+                    if(this.controller!.using_sorting_icon(tvi)){
+                        return;
+                    }else{
+                        tvi.iconPath = ICON_GROUP;
+                    }
+                 }
             });
         } else {
             this.controller!.activateGroup(group.get_full_uri(), wsf!);

--- a/src/views/bookmark_x/constants.ts
+++ b/src/views/bookmark_x/constants.ts
@@ -25,8 +25,11 @@ export const SAVED_WSFSDATA_KEY    = "bookmarkDemo.wsfsData";
 // icons
 // colors are controlled by contributes.
 export const ICON_BOOKMARK = new ThemeIcon("bookmark");
-export const ICON_ACTIVE_GROUP = new ThemeIcon("folder-opened", new ThemeColor("statusBarItem.remoteBackground"));
+export const ICON_ACTIVE_GROUP = new ThemeIcon("folder-opened", new ThemeColor("bookmark_x.activeGroupColor"));
 export const ICON_GROUP = new ThemeIcon("folder");
+export const ICON_SORTING_BOOKMARK = new ThemeIcon("bookmark", new ThemeColor("bookmark_x.sortingItemColor"))
+export const ICON_SORTING_ACTIVE_GROUP = new ThemeIcon("folder-opened", new ThemeColor("bookmark_x.sortingItemColor"));
+export const ICON_SORTING_GROUP = new ThemeIcon("folder", new ThemeColor("bookmark_x.sortingItemColor"));
 
 export const WSF_TVI_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><title>folder_type_vscode_opened</title><path d="M27.4,5.5H18.2L16.1,9.7H4.3v4H.5L4.3,26.5H29.5V5.5ZM20.2,7.6h7.1V9.7H19.2Zm5.5,6.1H6.6V11.8H27.4v7.626Z" style="fill:#7bb4db"/><path d="M30.257,12.333l-4.324-2.082a1.308,1.308,0,0,0-1.492.253L10.285,23.411a.875.875,0,0,0-.057,1.236.766.766,0,0,0,.057.057l1.157,1.052a.873.873,0,0,0,1.116.049L29.607,12.873A.868.868,0,0,1,31,13.565v-.05A1.311,1.311,0,0,0,30.257,12.333Z" style="fill:#0065a9"/><path d="M30.257,28.788,25.933,30.87a1.308,1.308,0,0,1-1.492-.253L10.285,17.71a.875.875,0,0,1-.057-1.236.766.766,0,0,1,.057-.057l1.157-1.052a.873.873,0,0,1,1.116-.049L29.607,28.248A.868.868,0,0,0,31,27.556v.05A1.311,1.311,0,0,1,30.257,28.788Z" style="fill:#007acc"/><path d="M25.933,30.871a1.308,1.308,0,0,1-1.491-.254.768.768,0,0,0,1.311-.543V11.047a.768.768,0,0,0-1.311-.543,1.306,1.306,0,0,1,1.491-.254l4.324,2.079A1.314,1.314,0,0,1,31,13.512v14.1a1.314,1.314,0,0,1-.743,1.183Z" style="fill:#1f9cf0"/></svg>`;
 export const SVG_BOOKMARK = `<svg id="layer1" data-name="layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 32 32"><defs><style>.cls-1{fill:url(#v);}</style><linearGradient id="v" x1="-3.34" y1="16.24" x2="37.41" y2="15.73" gradientUnits="userSpaceOnUse"><stop offset="0.19" stop-color="#00d39c"/><stop offset="0.75" stop-color="#008c86"/></linearGradient></defs><title>bookmark x logo</title><path class="cls-1" d="M25.8,2.5H9.1A3.55,3.55,0,0,0,5.55,6h0V29.5H22.26V6H15V16.15l-2.66-1.28L9.72,16.15V6H6.84A2.26,2.26,0,0,1,9.1,3.79H25.16V26.6a.65.65,0,1,0,1.29,0V3.15A.65.65,0,0,0,25.8,2.5Z"/></svg>`;

--- a/src/views/bookmark_x/contributes.jsonc
+++ b/src/views/bookmark_x/contributes.jsonc
@@ -272,6 +272,28 @@
 					]
 				}
 			}
-		}
+		},
+		"colors": [
+			{
+				"id": "bookmark_x.activeGroupColor",
+				"description": "Color for icon of active group",
+				"defaults": {
+					"dark": "statusBarItem.remoteBackground",
+					"light": "statusBarItem.remoteBackground",
+					"highContrast": "statusBarItem.remoteBackground",
+					"highContrastLight": "statusBarItem.remoteBackground"
+				}
+			},
+			{
+				"id": "bookmark_x.sortingItemColor",
+				"description": "Color for icon of sorting item",
+				"defaults":{
+					"dark": "#007acc",
+					"light": "#007acc",
+					"highContrast": "#007acc",
+					"highContrastLight": "#007acc"
+				}
+			}
+		]
 	}
 }

--- a/src/views/bookmark_x/controller.ts
+++ b/src/views/bookmark_x/controller.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { Bookmark, GroupBookmark, NodeType, RootGroup } from "./functional_types";
 import { Group } from './functional_types';
 import { SerializableGroup } from './serializable_type';
-import {ITEM_TYPE_BM, ITEM_TYPE_GROUP, ITEM_TYPE_GROUP_LIKE} from "./constants";
+import { ITEM_TYPE_BM, ITEM_TYPE_GROUP, ITEM_TYPE_GROUP_LIKE, ITEM_TYPE_GROUPBM } from "./constants";
 import * as bmutil from './util';
 import * as commonUtil from '../utils/util';
 import { typeIsBookmarkLike } from './constants';
@@ -25,10 +25,11 @@ import { BookmarkTreeItem, BookmarkTreeItemFactory } from './bookmark_tree_item'
 import { BookmarkTreeViewManager } from './bookmark_tree_view';
 import { error } from 'console';
 import { SAVED_WSFSDATA_KEY } from './constants';
+import { ICON_BOOKMARK, ICON_ACTIVE_GROUP, ICON_GROUP, ICON_SORTING_BOOKMARK, ICON_SORTING_ACTIVE_GROUP, ICON_SORTING_GROUP } from "./constants"
 
 export class SpaceMap {
-    static root_group_map: {[key: string]: RootGroup} = {};
-    static active_group_map: {[key: string]: Group} = {};
+    static root_group_map: { [key: string]: RootGroup } = {};
+    static active_group_map: { [key: string]: Group } = {};
 
     static get wsfs() {
         if (vscode.workspace.workspaceFolders) {
@@ -62,7 +63,7 @@ export class SpaceSortItem {
     }
 }
 
-type WsfDataSerialiable = {rg: {[key: string]: any}, ag: {[key: string]: any}};
+type WsfDataSerialiable = { rg: { [key: string]: any }, ag: { [key: string]: any } };
 
 export class Controller {
 
@@ -103,9 +104,39 @@ export class Controller {
         return SpaceMap.active_group_map[wsf.uri.path];
     }
 
+    public using_active_icon(item: BookmarkTreeItem): Boolean {
+        let wsf = this.get_wsf_with_node(item.base!);
+        let active_group = this.get_active_group(wsf!);
+        if (ITEM_TYPE_GROUP_LIKE.includes(item.base!.type)) {
+            let group = item.base as Group;
+            return bmutil.isSubUriOrEqual(group.get_full_uri(), active_group.get_full_uri());
+        }
+        return false;
+    }
+
+    public using_sorting_icon(item: BookmarkTreeItem): Boolean {
+        return SpaceSortItem.sorting_item === item
+    }
+
 
     public disableItemSorting(item: BookmarkTreeItem) {
         item.contextValue = SpaceSortItem.sorting_ctx;
+        if (this.using_active_icon(item)) {
+            // the deselected item is using active group icon now.
+            item.iconPath = ICON_ACTIVE_GROUP;
+        } else {
+            switch (item.base!.type) {
+                case ITEM_TYPE_GROUP:
+                case ITEM_TYPE_GROUPBM:
+                    item.iconPath = ICON_GROUP;
+                    break;
+                case ITEM_TYPE_BM:
+                    item.iconPath = ICON_BOOKMARK;
+                    break;
+                default:
+                    break;
+            }
+        }
         SpaceSortItem.sorting_item = undefined;
         SpaceSortItem.sorting_ctx = undefined;
         this.updateDecorations();
@@ -118,12 +149,42 @@ export class Controller {
         if (SpaceSortItem.sorting_item !== undefined) {
             let old_tvitem = SpaceSortItem.sorting_item;
             old_tvitem.contextValue = SpaceSortItem.sorting_ctx;
+            if (this.using_active_icon(old_tvitem)) {
+                // the deselected item is using active group icon now.
+                old_tvitem.iconPath = ICON_ACTIVE_GROUP;
+            } else {
+                switch (old_tvitem.base!.type) {
+                    case ITEM_TYPE_GROUP:
+                    case ITEM_TYPE_GROUPBM:
+                        old_tvitem.iconPath = ICON_GROUP;
+                        break;
+                    case ITEM_TYPE_BM:
+                        old_tvitem.iconPath = ICON_BOOKMARK;
+                        break;
+                    default:
+                        break;
+                }
+            }
         }
         SpaceSortItem.sorting_item = item;
         SpaceSortItem.sorting_ctx = item.contextValue;
         item.contextValue = "sortItem";
-        // TODO support icon change
 
+        if (this.using_active_icon(item)) {
+            item.iconPath = ICON_SORTING_ACTIVE_GROUP;
+        } else {
+            switch (item.base!.type) {
+                case ITEM_TYPE_GROUP:
+                case ITEM_TYPE_GROUPBM:
+                    item.iconPath = ICON_SORTING_GROUP;
+                    break;
+                case ITEM_TYPE_BM:
+                    item.iconPath = ICON_SORTING_BOOKMARK;
+                    break;
+                default:
+                    break;
+            }
+        }
 
         this.updateDecorations();
         this.saveState();
@@ -223,7 +284,7 @@ export class Controller {
         }
     }
     public saveWsfsState() {
-        let res: WsfDataSerialiable = {rg:{}, ag:{}};
+        let res: WsfDataSerialiable = { rg: {}, ag: {} };
         workspace.workspaceFolders?.forEach(wsf => {
             res.rg[wsf.uri.path] = SpaceMap.root_group_map[wsf.uri.path].serialize();
             res.ag[wsf.uri.path] = SpaceMap.active_group_map[wsf.uri.path].get_full_uri();
@@ -237,7 +298,7 @@ export class Controller {
             return;
         } else {
             // let data = this.ctx.workspaceState.update(SAVED_WSFSDATA_KEY, undefined);
-            let data: WsfDataSerialiable = this.ctx.workspaceState.get(SAVED_WSFSDATA_KEY) ?? {rg: {}, ag: {}};
+            let data: WsfDataSerialiable = this.ctx.workspaceState.get(SAVED_WSFSDATA_KEY) ?? { rg: {}, ag: {} };
             workspace.workspaceFolders.forEach(wsf => {
                 let rg = data.rg[wsf.uri.path];
                 let ag = data.ag[wsf.uri.path];
@@ -263,7 +324,7 @@ export class Controller {
             rg.sortGroupBookmark();
             console.log("node map keys:", rg.cache.keys());
             console.log("view item map keys:", rg.vicache.keys());
-            console.log("restore saved state done");  
+            console.log("restore saved state done");
         });
     }
 
@@ -300,7 +361,7 @@ export class Controller {
      * @param {type} param1 - param1 desc
      * @returns {type} - return value desc
      */
-    public actionToggleLabeledBookmark(textEditor: TextEditor, force=false) {
+    public actionToggleLabeledBookmark(textEditor: TextEditor, force = false) {
         if (textEditor.selections.length === 0) {
             return;
         }
@@ -338,7 +399,7 @@ export class Controller {
         });
     }
 
-    public inputBoxGetName(value="") {
+    public inputBoxGetName(value = "") {
         return window.showInputBox({
             placeHolder: "node name",
             prompt: "Please enter a new node name",
@@ -379,7 +440,7 @@ export class Controller {
         });
     }
 
-    public async doSaveSerializedRoot(wsf: vscode.WorkspaceFolder|null=null) {
+    public async doSaveSerializedRoot(wsf: vscode.WorkspaceFolder | null = null) {
         if (wsf === null) {
             wsf = workspace.workspaceFolders![0];
         }
@@ -394,7 +455,7 @@ export class Controller {
         await workspace.fs.writeFile(uri, bytes);
         window.showInformationMessage("saved.");
     }
-    public async doLoadSerializedRoot(wsf: vscode.WorkspaceFolder|null=null) {
+    public async doLoadSerializedRoot(wsf: vscode.WorkspaceFolder | null = null) {
         if (wsf === null) {
             wsf = workspace.workspaceFolders![0];
         }
@@ -525,7 +586,7 @@ export class Controller {
         tvitem.label = val;
 
         rg.vicache.del(node.get_full_uri());
-        
+
         let father = this._editNodeLabel(node, val, wsf!);
         if (father) {
             father.sortGroupBookmark();
@@ -544,9 +605,9 @@ export class Controller {
         let wsf = this.get_wsf_with_node(group);
         if (group.children.length > 0) {
             let val = await
-            window.showInformationMessage(
-                "the group not empty, do you really want to delete it?", 'yes', 'no'
-            );
+                window.showInformationMessage(
+                    "the group not empty, do you really want to delete it?", 'yes', 'no'
+                );
             if (val === 'yes') {
                 this.deleteGroups(group, wsf!);
                 return true;
@@ -604,7 +665,7 @@ export class Controller {
      * @param {Boolean} force - delete the exist bm and create new.
      * @returns {Boolean} - success or fail
      */
-    public addBookmark(bm: Bookmark, force=false): boolean {
+    public addBookmark(bm: Bookmark, force = false): boolean {
         // uri confliction
         let wsf = commonUtil.getWsfWithPath(bm.fsPath);
         let rg = this.get_root_group(wsf!);
@@ -839,7 +900,7 @@ export class Controller {
                     window.showInformationMessage("current bookmark: " + item.get_full_uri());
                     let wsf = this.get_wsf_with_node(item);
                     let tvitem = this.get_root_group(wsf!).vicache.get(item.get_full_uri());
-                    BookmarkTreeViewManager.view.reveal(tvitem, {focus: true});
+                    BookmarkTreeViewManager.view.reveal(tvitem, { focus: true });
                 }
             });
         }
@@ -875,7 +936,7 @@ export class Controller {
         let res = workspace.workspaceFolders?.find(wsf => wsf.uri.path === path);
         return res!;
     }
-    
+
     async selectBookmark(option: string) {
         let wsf = commonUtil.getWsfWithActiveEditor();
 

--- a/src/views/bookmark_x/functional_types.ts
+++ b/src/views/bookmark_x/functional_types.ts
@@ -3,6 +3,7 @@ import { SerializableBookmark, SerializableGroup, SerializableGroupBookmark } fr
 import { ICON_ACTIVE_GROUP, ICON_GROUP, ITEM_TYPE_BM, ITEM_TYPE_GROUP, ITEM_TYPE_GROUPBM, ITEM_TYPE_GROUP_LIKE, typeIsGroupLike, } from './constants';
 import * as util from './util';
 import { BookmarkTreeItem, BookmarkTreeItemFactory } from './bookmark_tree_item';
+import { SpaceSortItem } from './controller';
 
 export type NodeType = Group | Bookmark | GroupBookmark;
 export type GroupLike = Group | GroupBookmark;
@@ -379,6 +380,10 @@ export class ViewItemUriMap extends UriMap<BookmarkTreeItem> {
         this.keys().forEach(key => {
             // reset icon status
             let tvi = this.get(key);
+            if(SpaceSortItem.sorting_item === tvi){
+                // item is sorting, use sorting icon
+                return;
+            }
             if (ITEM_TYPE_GROUP_LIKE.includes(tvi.base!.type)) {
                 if (util.isSubUriOrEqual(key, new_full_uri)) {
                     tvi.iconPath = ICON_ACTIVE_GROUP;


### PR DESCRIPTION
When activating/deactivating a group, if a parent group of the active group is sorting, the parent group will keep using sorting icon.
![sorting_icon_change](https://github.com/user-attachments/assets/59b459c6-165f-46d7-aafa-7cd41bd0c072)
